### PR TITLE
Fix fundamentals report bug

### DIFF
--- a/tradingagents/agents/managers/risk_manager.py
+++ b/tradingagents/agents/managers/risk_manager.py
@@ -11,7 +11,7 @@ def create_risk_manager(llm, memory):
         risk_debate_state = state["risk_debate_state"]
         market_research_report = state["market_report"]
         news_report = state["news_report"]
-        fundamentals_report = state["news_report"]
+        fundamentals_report = state["fundamentals_report"]
         sentiment_report = state["sentiment_report"]
         trader_plan = state["investment_plan"]
 


### PR DESCRIPTION
## Summary
- fix variable to read `fundamentals_report` in risk manager

## Testing
- `python -m py_compile tradingagents/agents/managers/risk_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68491e6870048322a7b635cf3c1115bd